### PR TITLE
Fix cross-browser paste support for Firefox and Safari

### DIFF
--- a/package/lib/hook/usePasscode.test.tsx
+++ b/package/lib/hook/usePasscode.test.tsx
@@ -48,9 +48,32 @@ describe("test basic workflow", () => {
         await waitFor(() => {
             expect(secondtInput).toHaveFocus();
         });
+
+        // Verify that the value of first input is 1
+        expect(firstInput).toHaveValue("1");
     });
 
-    it("3. test if the focus changes to previous element when backspaced", async () => {
+
+    it("3. test if the focus changes to next element when the zero digit is typed", async () => {
+        render(<TestComponent isAlphaNumeric={false} />);
+        // focus on the first input
+        const firstInput: HTMLInputElement = screen.getByTestId("index-0");
+        firstInput.focus();
+        expect(firstInput).toHaveFocus();
+
+        //Type in first input and check the focus of next input
+        userEvent.type(firstInput, "0");
+        const secondtInput: HTMLInputElement = screen.getByTestId("index-1");
+        await waitFor(() => {
+            expect(secondtInput).toHaveFocus();
+        });
+
+        // Verify that the value of first input is 0
+        expect(firstInput).toHaveValue("0");
+    });
+
+
+    it("4. test if the focus changes to previous element when backspaced", async () => {
         render(<TestComponent isAlphaNumeric={false} />);
         // focus on the first input
         const firstInput: HTMLInputElement = screen.getByTestId("index-0");
@@ -58,9 +81,9 @@ describe("test basic workflow", () => {
 
         //Type in first input and check the focus of next input
         userEvent.type(firstInput, "1");
-        const secondtInput: HTMLInputElement = screen.getByTestId("index-1");
+        const secondInput: HTMLInputElement = screen.getByTestId("index-1");
         await waitFor(() => {
-            expect(secondtInput).toHaveFocus();
+            expect(secondInput).toHaveFocus();
         });
 
         //Backspace and observe focus shift
@@ -68,5 +91,32 @@ describe("test basic workflow", () => {
         await waitFor(() => {
             expect(firstInput).toHaveFocus();
         });
+
+        // Verify that the value of second input is empty
+        expect(secondInput).toHaveValue("");
+    });
+
+
+    it("5. test if the focus changes to previous element when backspaced over the zero digit", async () => {
+        render(<TestComponent isAlphaNumeric={false} />);
+        // focus on the first input
+        const firstInput: HTMLInputElement = screen.getByTestId("index-0");
+        firstInput.focus();
+
+        //Type in first input and check the focus of next input
+        userEvent.type(firstInput, "0");
+        const secondInput: HTMLInputElement = screen.getByTestId("index-1");
+        await waitFor(() => {
+            expect(secondInput).toHaveFocus();
+        });
+
+        //Backspace and observe focus shift
+        userEvent.keyboard("{Backspace}");
+        await waitFor(() => {
+            expect(firstInput).toHaveFocus();
+        });
+
+        // Verify that the value of second input is empty
+        expect(secondInput).toHaveValue("");
     });
 });

--- a/package/lib/hook/usePasscode.ts
+++ b/package/lib/hook/usePasscode.ts
@@ -10,6 +10,7 @@ import {
     getClipboardContent,
     getClipboardReadPermission,
     getFilledArray,
+    isNumeric,
     shouldPreventDefault,
 } from "../utils";
 
@@ -75,7 +76,7 @@ const usePasscode = (props: PasscodeProps) => {
                 if (
                     (isAlphaNumeric
                         ? ALPHANUMERIC_REGEX.test(e.key)
-                        : parseInt(e.key)) &&
+                        : isNumeric(e.key)) &&
                     index <= passcode.length - 2
                 ) {
                     setCurrentFocusedIndex(index + 1);

--- a/package/lib/hook/usePasscode.ts
+++ b/package/lib/hook/usePasscode.ts
@@ -1,5 +1,6 @@
 import {
     BaseSyntheticEvent,
+    ClipboardEvent,
     KeyboardEvent,
     useRef,
     useState,
@@ -7,8 +8,6 @@ import {
 } from "react";
 import {
     ALPHANUMERIC_REGEX,
-    getClipboardContent,
-    getClipboardReadPermission,
     getFilledArray,
     isNumeric,
     shouldPreventDefault,
@@ -98,15 +97,14 @@ const usePasscode = (props: PasscodeProps) => {
             }
         };
 
-        const onPaste = async (e: BaseSyntheticEvent) => {
-            const copyPermission = await getClipboardReadPermission();
-            if (copyPermission.state === "denied") {
-                throw new Error("Not allowed to read clipboard.");
-            }
+        const onPaste = (e: ClipboardEvent<HTMLInputElement>) => {
+            const clipboardContent = e.clipboardData?.getData("text");
+            if (!clipboardContent) return;
 
-            const clipboardContent = await getClipboardContent();
+            e.preventDefault();
+
             try {
-                // We convert the clipboard conent into an passcode of string or number depending upon isAlphaNumeric;
+                // We convert the clipboard content into a passcode of string or number depending upon isAlphaNumeric;
                 let newArray: Array<string | number> =
                     clipboardContent.split("");
                 newArray = isAlphaNumeric

--- a/package/lib/utils/index.ts
+++ b/package/lib/utils/index.ts
@@ -1,14 +1,17 @@
 export const ALPHANUMERIC_REGEX = /^[a-z0-9]$/i;
 
+
+export const isNumeric = (key: string) => !isNaN(Number(key))
+
 export const shouldPreventDefault = (
     key: string,
     isAlphaNumeric: boolean = false,
     isMeta: boolean = false
 ) => {
-    const parsed = Number(key);
-
+    // Check if the key is a number
+    const isKeyNumeric = isNumeric(key);
     // By default we only allow numbers to be pressed = DONE
-    if (parsed) return false;
+    if (isKeyNumeric) return false;
 
     // Crtl + V
     if (isMeta && key === "v") return false;
@@ -17,7 +20,7 @@ export const shouldPreventDefault = (
     if (key === "Backspace") return false;
 
     // We only allow alphabets to be pressed when the isAplhaNumeric flag is true = DONE
-    if (isAlphaNumeric && isNaN(parsed)) {
+    if (isAlphaNumeric && !isKeyNumeric) {
         return false;
     }
 

--- a/package/lib/utils/index.ts
+++ b/package/lib/utils/index.ts
@@ -27,16 +27,6 @@ export const shouldPreventDefault = (
     return true;
 };
 
-export const getClipboardReadPermission = () => {
-    return navigator.permissions.query({
-        name: "clipboard-read" as PermissionName,
-    });
-};
-
-export const getClipboardContent = () => {
-    return navigator.clipboard.readText();
-};
-
 /**
  *
  * @param arr

--- a/package/lib/utils/utils.test.ts
+++ b/package/lib/utils/utils.test.ts
@@ -5,6 +5,9 @@ describe("test shouldPreventDefault", () => {
         let key = "1";
         expect(shouldPreventDefault(key)).toBeFalsy();
 
+        key = "0";
+        expect(shouldPreventDefault(key)).toBeFalsy();
+
         key = "v";
         expect(shouldPreventDefault(key, false, true)).toBeFalsy();
 


### PR DESCRIPTION
## Summary

Replace `navigator.permissions.query({ name: 'clipboard-read' })` with `e.clipboardData.getData('text')` for cross-browser paste support.

## Problem

The `onPaste` handler uses `navigator.permissions.query({ name: 'clipboard-read' })` which is only supported in Chromium-based browsers. This causes TypeErrors in Firefox and Safari:

**Firefox:**
```
TypeError: 'clipboard-read' (value of 'name' member of PermissionDescriptor) is not a valid value for enumeration PermissionName.
```

**Safari:**
```
TypeError: Type error
```

## Solution

Use the paste event's `clipboardData` directly, which is supported across all browsers:

```typescript
const onPaste = (e: ClipboardEvent<HTMLInputElement>) => {
    const clipboardContent = e.clipboardData?.getData("text");
    if (!clipboardContent) return;
    e.preventDefault();
    // ... rest of paste handling
};
```

## Changes

- Changed `onPaste` from async to sync
- Use `e.clipboardData?.getData("text")` instead of permission query + clipboard API
- Removed unused `getClipboardReadPermission()` and `getClipboardContent()` utility functions

## Test plan

- [x] All existing tests pass
- [ ] Manual test paste in Chrome
- [ ] Manual test paste in Firefox  
- [ ] Manual test paste in Safari